### PR TITLE
Fixed signup page's errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     arel (7.1.4)
-    autoprefixer-rails (6.5.1)
+    autoprefixer-rails (6.6.1)
       execjs
     bcrypt (3.1.11)
     bootstrap-sass (3.3.6)
@@ -245,4 +245,4 @@ DEPENDENCIES
   will_paginate (= 3.1.0)
 
 BUNDLED WITH
-   1.13.1
+   1.13.5

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -50,6 +50,8 @@ h3{
     display: inline-block;
 
 }
+
+
 /*Logo*/
 .navbar-brand {
   margin-top: -7px;

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -55,19 +55,12 @@ div {
   color: green;
 }
 
-.field_with_errors {
-  padding: 2px;
-  background-color: red;
-  display: table;
-}
+
 
 #error_explanation {
-  width: 450px;
-  border: 2px solid red;
-  padding: 7px;
+  width: 100%;
   padding-bottom: 0;
   margin-bottom: 20px;
-  background-color: #f0f0f0;
 
   h2 {
     text-align: left;

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,7 +7,7 @@
 <div class="row">
     <div class = "col-md-6 col-md-offset-3">
         <%= form_for(@user) do |f| %>
-            <%= render 'shared/error_messages' %>
+           <%= render 'shared/error_messages' %> 
             
             <%= f.label :name %>
             <%= f.text_field :name, class: 'form-control' %>


### PR DESCRIPTION
Bootstrap 3.0 was causing the ugly errors in the signup. I tried downgrading, but that caused further issues. Instead, I opened up the auto generated CSS, and disabled the field highlighting altogether. I find its still functional, and looks better this way.

The footer was only affected on that screen I believe, regardless, it was never a problem for my computer (because it's 16X10?). So test it with yours please.